### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,7 @@ Curebit.prototype.page = function() {
 };
 
 /**
- * Completed order.
+ * Order completed.
  *
  * Fire the Curebit `register_purchase` with the order details and items.
  *
@@ -151,7 +151,7 @@ Curebit.prototype.page = function() {
  * @param {Track} track
  */
 
-Curebit.prototype.completedOrder = function(track) {
+Curebit.prototype.orderCompleted = function(track) {
   var user = this.analytics.user();
   var orderId = track.orderId();
   var products = track.products();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -159,7 +159,7 @@ describe('Curebit', function() {
       });
     });
 
-    describe('#completedOrder', function() {
+    describe('#orderCompleted', function() {
       beforeEach(function() {
         analytics.stub(window._curebitq, 'push');
       });
@@ -167,7 +167,7 @@ describe('Curebit', function() {
       it('should send ecommerce data', function() {
         var date = new Date();
 
-        analytics.track('completed order', {
+        analytics.track('order completed', {
           orderId: 'ab535a52',
           coupon: 'save20',
           date: date,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
